### PR TITLE
Disable cursive's default features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ categories = ["command-line-interface", "gui"]
 license = "MIT/Apache-2.0"
 
 [dependencies]
-cursive = "0.5"
+cursive = { version = "0.5", default-features = false }
 
 [features]
 default = ["ncurses-backend"]


### PR DESCRIPTION
Since backends are currently incompatible, we need to disable cursive's default `ncurses-backend` feature, otherwise adding another one will result in a compilation error.