### PR TITLE
Fix for `insert_item` after alread loaded items via `set_items`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cursive_table_view"
-version = "0.8.0"
+version = "0.7.0"
 authors = ["Ivo Wetzel <ivo.wetzel@googlemail.com>"]
 description = "A basic table view implementation for cursive."
 repository = "https://github.com/BonsaiDen/cursive_table_view.git"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cursive_table_view"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Ivo Wetzel <ivo.wetzel@googlemail.com>"]
 description = "A basic table view implementation for cursive."
 repository = "https://github.com/BonsaiDen/cursive_table_view.git"
@@ -22,4 +22,3 @@ blt-backend = ["cursive/blt-backend"]
 
 [dev-dependencies]
 rand = "0.6"
-

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-cursive_table_view = "0.7.0"
+cursive_table_view = "0.8.0"
 ```
 
 and this to your crate root:
@@ -39,7 +39,7 @@ default-features = false
 features = ["blt-backend"]
 
 [dependencies.cursive_table_view]
-version = "0.7.0"
+version = "0.8.0"
 default-features = false
 features = ["blt-backend"]
 ```
@@ -57,4 +57,3 @@ at your option.
 Unless you explicitly state otherwise, any contribution intentionally submitted
 for inclusion in the work by you shall be dual licensed as above, without any
 additional terms or conditions.
-

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-cursive_table_view = "0.8.0"
+cursive_table_view = "0.7.0"
 ```
 
 and this to your crate root:
@@ -39,7 +39,7 @@ default-features = false
 features = ["blt-backend"]
 
 [dependencies.cursive_table_view]
-version = "0.8.0"
+version = "0.7.0"
 default-features = false
 features = ["blt-backend"]
 ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1017,9 +1017,13 @@ mod tests {
     }
 
     fn setup_test_table() -> TableView<SimpleItem, SimpleColumn> {
-        let mut simple_table =
-            TableView::<SimpleItem, SimpleColumn>::new()
-                .column(SimpleColumn::Name, "Name", |c| c.width_percent(20));
+        TableView::<SimpleItem, SimpleColumn>::new()
+            .column(SimpleColumn::Name, "Name", |c| c.width_percent(20))
+    }
+
+    #[test]
+    fn should_insert_into_existing_table() {
+        let mut simple_table = setup_test_table();
 
         let mut simple_items = Vec::new();
 
@@ -1032,13 +1036,6 @@ mod tests {
         // Insert First Batch of Items
         simple_table.set_items(simple_items);
 
-        simple_table
-    }
-
-    #[test]
-    fn should_insert_into_existing_collection() {
-        let mut simple_table = setup_test_table();
-
         // Test for Additional item insertion
         simple_table.insert_item(SimpleItem {
             name: format!("{} Name", 11),
@@ -1046,4 +1043,17 @@ mod tests {
 
         assert!(simple_table.len() == 11);
     }
+
+    #[test]
+    fn should_insert_into_empty_table() {
+        let mut simple_table = setup_test_table();
+
+        // Test for First item insertion
+        simple_table.insert_item(SimpleItem {
+            name: format!("{} Name", 1),
+        });
+
+        assert!(simple_table.len() == 1);
+    }
+
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -516,7 +516,7 @@ impl<T: TableViewItem<H>, H: Eq + Hash + Copy + Clone + 'static> TableView<T, H>
     /// newly inserted item.
     pub fn insert_item(&mut self, item: T) {
         self.items.push(item);
-        self.rows_to_items.push(self.items.len());
+        self.rows_to_items.push(self.items.len() - 1);
 
         self.scrollbase
             .set_heights(self.last_size.y.saturating_sub(2), self.rows_to_items.len());
@@ -973,5 +973,77 @@ impl<H: Copy + Clone + 'static> TableColumn<H> {
         };
 
         printer.print((0, 0), value.as_str());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Copy, Clone, PartialEq, Eq, Hash)]
+    enum SimpleColumn {
+        Name,
+    }
+
+    #[allow(dead_code)]
+    impl SimpleColumn {
+        fn as_str(&self) -> &str {
+            match *self {
+                SimpleColumn::Name => "Name",
+            }
+        }
+    }
+
+    #[derive(Clone, Debug)]
+    struct SimpleItem {
+        name: String,
+    }
+
+    impl TableViewItem<SimpleColumn> for SimpleItem {
+        fn to_column(&self, column: SimpleColumn) -> String {
+            match column {
+                SimpleColumn::Name => self.name.to_string(),
+            }
+        }
+
+        fn cmp(&self, other: &Self, column: SimpleColumn) -> Ordering
+        where
+            Self: Sized,
+        {
+            match column {
+                SimpleColumn::Name => self.name.cmp(&other.name),
+            }
+        }
+    }
+
+    fn setup_test_table() -> TableView<SimpleItem, SimpleColumn> {
+        let mut simple_table =
+            TableView::<SimpleItem, SimpleColumn>::new()
+                .column(SimpleColumn::Name, "Name", |c| c.width_percent(20));
+
+        let mut simple_items = Vec::new();
+
+        for i in 1..=10 {
+            simple_items.push(SimpleItem {
+                name: format!("{} - Name", i),
+            });
+        }
+
+        // Insert First Batch of Items
+        simple_table.set_items(simple_items);
+
+        simple_table
+    }
+
+    #[test]
+    fn should_insert_into_existing_collection() {
+        let mut simple_table = setup_test_table();
+
+        // Test for Additional item insertion
+        simple_table.insert_item(SimpleItem {
+            name: format!("{} Name", 11),
+        });
+
+        assert!(simple_table.len() == 11);
     }
 }


### PR DESCRIPTION
Hello @BonsaiDen / @gyscos , I had a small problem calling `insert_item` when a table is already loaded with `set_items`.

It seems that during the first copy of the items a zero index approach was used to store its positions in `row_to_items`, which is fine btw, but when calling `insert_item` after that we run in a `panic` with `out of bounds index error`.

- Bumped version to 0.8.0
- Wrote a small test case

Please, I'm pretty new to contributing PRs, your feedback is much appreciated...

Thx 