### PR TITLE
Bump to cursive 0.11.x

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ categories = ["command-line-interface", "gui"]
 license = "MIT/Apache-2.0"
 
 [dependencies]
-cursive = { version = "0.10", default-features = false }
+cursive = { version = "0.11", default-features = false }
 rand = "0.6"
 
 [features]

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ the identical features to your `cursive_table_view` dependency:
 
 ```toml
 [dependencies.cursive]
-version = "0.10"
+version = "0.11"
 default-features = false
 features = ["blt-backend"]
 


### PR DESCRIPTION
This simply bumps the cursive dependency to `0.11.x`.

Tests and examples have been tested and confirmed to work properly on Linux.