### PR TITLE
Simplify dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,14 +11,7 @@ license = "MIT/Apache-2.0"
 
 [dependencies]
 cursive = { version = "0.11", default-features = false }
-rand = "0.6"
-
-[features]
-default = ["ncurses-backend"]
-ncurses-backend = ["cursive/ncurses-backend"]
-pancurses-backend = ["cursive/pancurses-backend"]
-termion-backend = ["cursive/termion-backend"]
-blt-backend = ["cursive/blt-backend"]
 
 [dev-dependencies]
+cursive = "0.11"
 rand = "0.6"

--- a/README.md
+++ b/README.md
@@ -27,23 +27,6 @@ and this to your crate root:
 extern crate cursive_table_view;
 ```
 
-### Different backends
-
-If you are using `cursive` with a different backend, you'll need to *forward*
-the identical features to your `cursive_table_view` dependency:
-
-```toml
-[dependencies.cursive]
-version = "0.11"
-default-features = false
-features = ["blt-backend"]
-
-[dependencies.cursive_table_view]
-version = "0.8"
-default-features = false
-features = ["blt-backend"]
-```
-
 ## License
 
 Licensed under either of


### PR DESCRIPTION
The rand crate is only used by the examples.
For the library itself the cursive backend doesn't matter,
those feature can be safely removed. At least one backend
is necessary for the examples to work, re-enabling the default
features of cursive in dev-dependencies solve this.

This is technically a breaking change, bumping version to 0.9 would be necessary.