### PR TITLE
Bump rand dependency and fix example code syntax

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,4 +14,4 @@ cursive_core = "0.2"
 
 [dev-dependencies]
 cursive = "0.16"
-rand = "0.7"
+rand = "0.8"

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -82,8 +82,8 @@ fn main() {
     for i in 0..50 {
         items.push(Foo {
             name: format!("Name {}", i),
-            count: rng.gen_range(0, 255),
-            rate: rng.gen_range(0, 255),
+            count: rng.gen_range(0..255),
+            rate: rng.gen_range(0..255),
         });
     }
 

--- a/examples/double.rs
+++ b/examples/double.rs
@@ -75,8 +75,8 @@ fn create_table() -> TableView<Foo, BasicColumn> {
     for i in 0..50 {
         items.push(Foo {
             name: format!("Name {}", i),
-            count: rng.gen_range(0, 255),
-            rate: rng.gen_range(0, 255),
+            count: rng.gen_range(0..255),
+            rate: rng.gen_range(0..255),
         });
     }
 


### PR DESCRIPTION
Manually followed the example on a new project and it failed with the newest version of `rand`. I bumped the version and updated the syntax in the examples which now works. Tests still seemed to pass on MacOS, but I wasn't able to run them on Windows.