### PR TITLE
[RFC] Add ability not to follow selected item in the table

### DIFF
--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -99,19 +99,23 @@ fn main() {
         );
     });
 
-    table.set_on_submit(|siv: &mut Cursive, row: usize, index: usize| {
+    table.set_on_submit(|siv: &mut Cursive, row: Option<usize>, index: Option<usize>| {
+        if !index.is_some() {
+            return;
+        }
+
         let value = siv
             .call_on_name("table", move |table: &mut TableView<Foo, BasicColumn>| {
-                format!("{:?}", table.borrow_item(index).unwrap())
+                format!("{:?}", table.borrow_item(index.unwrap()).unwrap())
             })
             .unwrap();
 
         siv.add_layer(
             Dialog::around(TextView::new(value))
-                .title(format!("Removing row # {}", row))
+                .title(format!("Removing row # {}", row.unwrap()))
                 .button("Close", move |s| {
                     s.call_on_name("table", |table: &mut TableView<Foo, BasicColumn>| {
-                        table.remove_item(index);
+                        table.remove_item(index.unwrap());
                     });
                     s.pop_layer();
                 }),


### PR DESCRIPTION
It is not always useful to always select some item (i.e. first by
sorting order, by the way it is not even how it works natively since
sort_by() applied after, and you need to call set_selected_item(0) for
this).

Consider csysdig, by default when you did not press anything it stick to
the first item by sort order, and only if you select something (Up/Down)
then it will stick to this item in the table.

And this behaviour is better, since if you did not focus any item you
want to look at the items sorted by the sort order.

And I also made the Home button to cancel this selection.