### PR TITLE
Adopt for new multi-threaded cursive capabilities

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,12 @@ categories = ["command-line-interface", "gui"]
 license = "MIT/Apache-2.0"
 
 [dependencies]
-cursive_core = "0.3.0"
+cursive_core = "*"
 
 [dev-dependencies]
-cursive = "0.17.0"
+cursive = "*"
 rand = "0.8"
+
+[patch.crates-io]
+cursive = { git = "https://github.com/gyscos/cursive", branch = "main" }
+cursive_core = { git = "https://github.com/gyscos/cursive", branch = "main" }

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -99,19 +99,23 @@ fn main() {
         );
     });
 
-    table.set_on_submit(|siv: &mut Cursive, row: usize, index: usize| {
+    table.set_on_submit(|siv: &mut Cursive, row: Option<usize>, index: Option<usize>| {
+        if !index.is_some() {
+            return;
+        }
+
         let value = siv
             .call_on_name("table", move |table: &mut TableView<Foo, BasicColumn>| {
-                format!("{:?}", table.borrow_item(index).unwrap())
+                format!("{:?}", table.borrow_item(index.unwrap()).unwrap())
             })
             .unwrap();
 
         siv.add_layer(
             Dialog::around(TextView::new(value))
-                .title(format!("Removing row # {}", row))
+                .title(format!("Removing row # {}", row.unwrap()))
                 .button("Close", move |s| {
                     s.call_on_name("table", |table: &mut TableView<Foo, BasicColumn>| {
-                        table.remove_item(index);
+                        table.remove_item(index.unwrap());
                     });
                     s.pop_layer();
                 }),


### PR DESCRIPTION
**Note: this includes https://github.com/BonsaiDen/cursive_table_view/pull/40**

In [1] cursive now requires Send + Sync, and the reason for this is:

    The View now requires Send + Sync, to allow accessing or moving views between threads.
    This prevents using Rc/RefCell, and may require using Arc/Mutex instead.
    This should eventually open the way for more multi-threaded processing of the view tree.

  [1]: https://github.com/gyscos/cursive/commit/f1f25b1a4ebeacef7e1d2ad160244950d3308feb